### PR TITLE
WhatTheLocalization: add toggleable debug mode

### DIFF
--- a/WhatTheLocalization/scripts/mods/WhatTheLocalization/WhatTheLocalization.lua
+++ b/WhatTheLocalization/scripts/mods/WhatTheLocalization/WhatTheLocalization.lua
@@ -46,3 +46,14 @@ mod:hook(LocalizationManager, "_lookup", function(func, self, key)
 	end
 	return ret
 end)
+
+mod.in_debug_mode = false
+
+mod.toggle_debug_mode = function()
+	mod.in_debug_mode = not mod.in_debug_mode
+end
+
+mod:hook(LocalizationManager, "localize", function(func, self, key, no_cache, context)
+	local ret = func(self, key, no_cache, context)
+	return mod.in_debug_mode and key or ret
+end)

--- a/WhatTheLocalization/scripts/mods/WhatTheLocalization/WhatTheLocalization_data.lua
+++ b/WhatTheLocalization/scripts/mods/WhatTheLocalization/WhatTheLocalization_data.lua
@@ -4,4 +4,17 @@ return {
 	name = mod:localize("mod_name"),
 	description = mod:localize("mod_description"),
 	is_togglable = true,
+	options = {
+		widgets = {
+			{
+				setting_id = "toggle_debug_mode",
+				type = "keybind",
+				default_value = {},
+				keybind_global = true,
+				keybind_trigger = "pressed",
+				keybind_type = "function_call",
+				function_name = "toggle_debug_mode",
+			},
+		}
+	}
 }

--- a/WhatTheLocalization/scripts/mods/WhatTheLocalization/WhatTheLocalization_localization.lua
+++ b/WhatTheLocalization/scripts/mods/WhatTheLocalization/WhatTheLocalization_localization.lua
@@ -7,4 +7,8 @@ return {
 		en = "A community-driven localization fix framework.",
 		["zh-cn"] = "一个由社区驱动的翻译修复框架。",
 	},
+	toggle_debug_mode = {
+		en = "Toggle debug mode",
+		["zh-cn"] = "切换调试模式",
+	}
 }


### PR DESCRIPTION
Add a debug mode similar to DRG's, which reveals localization keys.

This is helpful for hunting bad translations and making contribution to this project.

![图片](https://github.com/deluxghost/darktide-mods/assets/18213435/d8fa85d7-c505-4fb9-9012-c89d1fc47cf5)
