### PR TITLE
Add class for new bolt pistol

### DIFF
--- a/crosshair_remap/scripts/mods/crosshair_remap/crosshair_remap.lua
+++ b/crosshair_remap/scripts/mods/crosshair_remap/crosshair_remap.lua
@@ -27,6 +27,7 @@ local keywords_to_class = {
 	},
 	autopistol = "autopistol_class",
 	bolter = "boltgun_class",
+	boltpistol = "boltpistol_class",
 	flamer = "flamer_class",
 	force_staff = {
 		p1 = "force_staff_trauma_class",

--- a/crosshair_remap/scripts/mods/crosshair_remap/crosshair_remap_data.lua
+++ b/crosshair_remap/scripts/mods/crosshair_remap/crosshair_remap_data.lua
@@ -58,6 +58,7 @@ return {
 			make_group("autogun_headhunter_class", "cross", "ironsight"),
 			make_group("autopistol_class", "assault", "assault"),
 			make_group("boltgun_class", "spray_n_pray", "ironsight"),
+			make_group("boltpistol_class", "spray_n_pray", "ironsight"),
 			make_group("flamer_class", "spray_n_pray", "spray_n_pray"),
 			make_group("force_staff_trauma_class", "assault", "charge_up"),
 			make_group("force_staff_purgatus_class", "spray_n_pray", "charge_up"),

--- a/crosshair_remap/scripts/mods/crosshair_remap/crosshair_remap_localization.lua
+++ b/crosshair_remap/scripts/mods/crosshair_remap/crosshair_remap_localization.lua
@@ -135,6 +135,9 @@ local locres = {
 		en = "Boltguns",
 		["zh-cn"] = "爆矢枪",
 	},
+	boltpistol_class = {
+		en = "Bolt Pistols",
+	},
 	flamer_class = {
 		en = "Flamers",
 		["zh-cn"] = "火焰喷射器",


### PR DESCRIPTION
Darktide CTDs without crosshair_remap having a class for the new Bolt Pistol. 

It should probably handle exceptions like this more gracefully, but for now, here's the simple fix. 