### PR TITLE
Update Japanese Lozalization

### DIFF
--- a/QuickLookCard/scripts/mods/QuickLookCard/QuickLookCard_localization.lua
+++ b/QuickLookCard/scripts/mods/QuickLookCard/QuickLookCard_localization.lua
@@ -274,7 +274,7 @@ return {
 	stat_loc_stats_display_heat_management_powersword_2h = {
 		en = "HTMG", -- Heat Management
 		["zh-cn"] = "热管", -- 热量管理
-		ja = "熱管", -- 熱量管理
+		ja = "熱制", -- 熱制御
 	},
 
 	-- Perks or blessings

--- a/QuickLookCard/scripts/mods/QuickLookCard/QuickLookCard_localization.lua
+++ b/QuickLookCard/scripts/mods/QuickLookCard/QuickLookCard_localization.lua
@@ -30,8 +30,8 @@ return {
 	},
 	opt_highlight_dump_stat = {
 		en = "Highlight modifier dump stat",
-		ja = "不要な補正値をハイライトする",
 		["zh-cn"] = "高亮显示五维短板",
+		ja = "不要な補正値をハイライトする",
 	},
 	opt_group_toggles = {
 		en = "Toggles",

--- a/QuickLookCard/scripts/mods/QuickLookCard/QuickLookCard_localization.lua
+++ b/QuickLookCard/scripts/mods/QuickLookCard/QuickLookCard_localization.lua
@@ -31,7 +31,7 @@ return {
 	opt_highlight_dump_stat = {
 		en = "Highlight modifier dump stat",
 		["zh-cn"] = "高亮显示五维短板",
-		ja = "不要な補正値をハイライトする",
+		ja = "最も値の低い補正値をハイライトする",
 	},
 	opt_group_toggles = {
 		en = "Toggles",

--- a/QuickLookCard/scripts/mods/QuickLookCard/QuickLookCard_localization.lua
+++ b/QuickLookCard/scripts/mods/QuickLookCard/QuickLookCard_localization.lua
@@ -19,15 +19,18 @@ return {
 	opt_modifier_mode_current = {
 		en = "Current value",
 		["zh-cn"] = "当前值",
+		ja = "現在の値",
 		ru = "Текущее значение",
 	},
 	opt_modifier_mode_potential = {
 		en = "Potential value",
 		["zh-cn"] = "潜力值",
+		ja = "最大値",
 		ru = "Возможное значение",
 	},
 	opt_highlight_dump_stat = {
 		en = "Highlight modifier dump stat",
+		ja = "不要な補正値をハイライトする",
 		["zh-cn"] = "高亮显示五维短板",
 	},
 	opt_group_toggles = {
@@ -271,6 +274,7 @@ return {
 	stat_loc_stats_display_heat_management_powersword_2h = {
 		en = "HTMG", -- Heat Management
 		["zh-cn"] = "热管", -- 热量管理
+		ja = "熱管", -- 熱量管理
 	},
 
 	-- Perks or blessings


### PR DESCRIPTION
I thought "Dump Stat" means "stat that is not a problem even if it is low", but in this case, the mod highlights the lowest modifier out of five. So I translated it to "Highlights the lowest stat" in Japanese. Is it okay?